### PR TITLE
Add stored Reader View support

### DIFF
--- a/Modules/Account/Sources/Account/Account.swift
+++ b/Modules/Account/Sources/Account/Account.swift
@@ -712,9 +712,13 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 	}
 
 	/// Fetch articleIDs for articles that we should have, but don’t. These articles are either (starred) or (newer than the article cutoff date).
-	public func fetchArticleIDsForStatusesWithoutArticlesNewerThanCutoffDate(_ completion: @escaping ArticleIDsCompletionBlock) {
-		database.fetchArticleIDsForStatusesWithoutArticlesNewerThanCutoffDate(completion)
-	}
+        public func fetchArticleIDsForStatusesWithoutArticlesNewerThanCutoffDate(_ completion: @escaping ArticleIDsCompletionBlock) {
+                database.fetchArticleIDsForStatusesWithoutArticlesNewerThanCutoffDate(completion)
+        }
+
+        public func saveExtractedArticle(_ extractedArticle: ExtractedArticle, articleID: String) {
+                database.saveExtractedArticle(extractedArticle, for: articleID)
+        }
 	
 	public func unreadCount(for webFeed: WebFeed) -> Int {
 		return unreadCounts[webFeed.webFeedID] ?? 0

--- a/Modules/Articles/Sources/Articles/Article.swift
+++ b/Modules/Articles/Sources/Articles/Article.swift
@@ -26,9 +26,10 @@ public struct Article: Hashable {
 	public let datePublished: Date?
 	public let dateModified: Date?
 	public let authors: Set<Author>?
-	public let status: ArticleStatus
+        public let status: ArticleStatus
+        public let extractedArticle: ExtractedArticle?
 
-	public init(accountID: String, articleID: String?, webFeedID: String, uniqueID: String, title: String?, contentHTML: String?, contentText: String?, url: String?, externalURL: String?, summary: String?, imageURL: String?, datePublished: Date?, dateModified: Date?, authors: Set<Author>?, status: ArticleStatus) {
+        public init(accountID: String, articleID: String?, webFeedID: String, uniqueID: String, title: String?, contentHTML: String?, contentText: String?, url: String?, externalURL: String?, summary: String?, imageURL: String?, datePublished: Date?, dateModified: Date?, authors: Set<Author>?, status: ArticleStatus, extractedArticle: ExtractedArticle? = nil) {
 		self.accountID = accountID
 		self.webFeedID = webFeedID
 		self.uniqueID = uniqueID
@@ -42,7 +43,8 @@ public struct Article: Hashable {
 		self.datePublished = datePublished
 		self.dateModified = dateModified
 		self.authors = authors
-		self.status = status
+                self.status = status
+                self.extractedArticle = extractedArticle
 		
 		if let articleID = articleID {
 			self.articleID = articleID
@@ -64,9 +66,9 @@ public struct Article: Hashable {
 
 	// MARK: - Equatable
 
-	static public func ==(lhs: Article, rhs: Article) -> Bool {
-		return lhs.articleID == rhs.articleID && lhs.accountID == rhs.accountID && lhs.webFeedID == rhs.webFeedID && lhs.uniqueID == rhs.uniqueID && lhs.title == rhs.title && lhs.contentHTML == rhs.contentHTML && lhs.contentText == rhs.contentText && lhs.rawLink == rhs.rawLink && lhs.rawExternalLink == rhs.rawExternalLink && lhs.summary == rhs.summary && lhs.rawImageLink == rhs.rawImageLink && lhs.datePublished == rhs.datePublished && lhs.dateModified == rhs.dateModified && lhs.authors == rhs.authors
-	}
+        static public func ==(lhs: Article, rhs: Article) -> Bool {
+                return lhs.articleID == rhs.articleID && lhs.accountID == rhs.accountID && lhs.webFeedID == rhs.webFeedID && lhs.uniqueID == rhs.uniqueID && lhs.title == rhs.title && lhs.contentHTML == rhs.contentHTML && lhs.contentText == rhs.contentText && lhs.rawLink == rhs.rawLink && lhs.rawExternalLink == rhs.rawExternalLink && lhs.summary == rhs.summary && lhs.rawImageLink == rhs.rawImageLink && lhs.datePublished == rhs.datePublished && lhs.dateModified == rhs.dateModified && lhs.authors == rhs.authors && lhs.extractedArticle == rhs.extractedArticle
+        }
 }
 
 public extension Set where Element == Article {

--- a/Modules/ArticlesDatabase/Package.swift
+++ b/Modules/ArticlesDatabase/Package.swift
@@ -16,14 +16,17 @@ let package = Package(
 		.package(path: "../RSParser"),
 		.package(path: "../RSDatabase"),
 	],
-	targets: [
-		.target(
-			name: "ArticlesDatabase",
-			dependencies: [
-				"RSCore",
-				"RSDatabase",
-				"RSParser",
-				"Articles",
-			]),
-	]
+        targets: [
+                .target(
+                        name: "ArticlesDatabase",
+                        dependencies: [
+                                "RSCore",
+                                "RSDatabase",
+                                "RSParser",
+                                "Articles",
+                        ]),
+                .testTarget(
+                        name: "ArticlesDatabaseTests",
+                        dependencies: ["ArticlesDatabase"]),
+        ]
 )

--- a/Modules/ArticlesDatabase/Sources/ArticlesDatabase/Constants.swift
+++ b/Modules/ArticlesDatabase/Sources/ArticlesDatabase/Constants.swift
@@ -33,11 +33,12 @@ struct DatabaseKey {
 	static let externalURL = "externalURL"
 	static let summary = "summary"
 	static let imageURL = "imageURL"
-	static let bannerImageURL = "bannerImageURL"
-	static let datePublished = "datePublished"
-	static let dateModified = "dateModified"
-	static let authors = "authors"
-	static let searchRowID = "searchRowID"
+        static let bannerImageURL = "bannerImageURL"
+        static let datePublished = "datePublished"
+        static let dateModified = "dateModified"
+        static let authors = "authors"
+        static let extractedArticle = "extractedArticle"
+        static let searchRowID = "searchRowID"
 	
 	// ArticleStatus
 	static let read = "read"

--- a/Modules/ArticlesDatabase/Sources/ArticlesDatabase/Extensions/Article+Database.swift
+++ b/Modules/ArticlesDatabase/Sources/ArticlesDatabase/Extensions/Article+Database.swift
@@ -34,11 +34,15 @@ extension Article {
 		let url = row.string(forColumn: DatabaseKey.url)
 		let externalURL = row.string(forColumn: DatabaseKey.externalURL)
 		let summary = row.string(forColumn: DatabaseKey.summary)
-		let imageURL = row.string(forColumn: DatabaseKey.imageURL)
-		let datePublished = row.date(forColumn: DatabaseKey.datePublished)
-		let dateModified = row.date(forColumn: DatabaseKey.dateModified)
+                let imageURL = row.string(forColumn: DatabaseKey.imageURL)
+                let datePublished = row.date(forColumn: DatabaseKey.datePublished)
+                let dateModified = row.date(forColumn: DatabaseKey.dateModified)
+                var extractedArticle: ExtractedArticle? = nil
+                if let data = row.data(forColumn: DatabaseKey.extractedArticle) {
+                        extractedArticle = try? JSONDecoder().decode(ExtractedArticle.self, from: data)
+                }
 
-		self.init(accountID: accountID, articleID: articleID, webFeedID: webFeedID, uniqueID: uniqueID, title: title, contentHTML: contentHTML, contentText: contentText, url: url, externalURL: externalURL, summary: summary, imageURL: imageURL, datePublished: datePublished, dateModified: dateModified, authors: nil, status: status)
+                self.init(accountID: accountID, articleID: articleID, webFeedID: webFeedID, uniqueID: uniqueID, title: title, contentHTML: contentHTML, contentText: contentText, url: url, externalURL: externalURL, summary: summary, imageURL: imageURL, datePublished: datePublished, dateModified: dateModified, authors: nil, status: status, extractedArticle: extractedArticle)
 	}
 
 	init(parsedItem: ParsedItem, maximumDateAllowed: Date, accountID: String, webFeedID: String, status: ArticleStatus) {
@@ -58,7 +62,7 @@ extension Article {
 			dateModified = nil
 		}
 
-		self.init(accountID: accountID, articleID: parsedItem.syncServiceID, webFeedID: webFeedID, uniqueID: parsedItem.uniqueID, title: parsedItem.title, contentHTML: parsedItem.contentHTML, contentText: parsedItem.contentText, url: parsedItem.url, externalURL: parsedItem.externalURL, summary: parsedItem.summary, imageURL: parsedItem.imageURL, datePublished: datePublished, dateModified: dateModified, authors: authors, status: status)
+                self.init(accountID: accountID, articleID: parsedItem.syncServiceID, webFeedID: webFeedID, uniqueID: parsedItem.uniqueID, title: parsedItem.title, contentHTML: parsedItem.contentHTML, contentText: parsedItem.contentText, url: parsedItem.url, externalURL: parsedItem.externalURL, summary: parsedItem.summary, imageURL: parsedItem.imageURL, datePublished: datePublished, dateModified: dateModified, authors: authors, status: status, extractedArticle: nil)
 	}
 
 	private func addPossibleStringChangeWithKeyPath(_ comparisonKeyPath: KeyPath<Article,String?>, _ otherArticle: Article, _ key: String, _ dictionary: inout DatabaseDictionary) {
@@ -71,7 +75,7 @@ extension Article {
 		if authors.isEmpty {
 			return self
 		}
-		return Article(accountID: self.accountID, articleID: self.articleID, webFeedID: self.webFeedID, uniqueID: self.uniqueID, title: self.title, contentHTML: self.contentHTML, contentText: self.contentText, url: self.rawLink, externalURL: self.rawExternalLink, summary: self.summary, imageURL: self.rawImageLink, datePublished: self.datePublished, dateModified: self.dateModified, authors: authors, status: self.status)
+                return Article(accountID: self.accountID, articleID: self.articleID, webFeedID: self.webFeedID, uniqueID: self.uniqueID, title: self.title, contentHTML: self.contentHTML, contentText: self.contentText, url: self.rawLink, externalURL: self.rawExternalLink, summary: self.summary, imageURL: self.rawImageLink, datePublished: self.datePublished, dateModified: self.dateModified, authors: authors, status: self.status, extractedArticle: self.extractedArticle)
 	}
 
 	func changesFrom(_ existingArticle: Article) -> DatabaseDictionary? {
@@ -169,11 +173,15 @@ extension Article: @retroactive DatabaseObject {
 		if let datePublished = datePublished {
 			d[DatabaseKey.datePublished] = datePublished
 		}
-		if let dateModified = dateModified {
-			d[DatabaseKey.dateModified] = dateModified
-		}
-		return d
-	}
+                if let dateModified = dateModified {
+                        d[DatabaseKey.dateModified] = dateModified
+                }
+                if let extractedArticle = extractedArticle,
+                   let data = try? JSONEncoder().encode(extractedArticle) {
+                        d[DatabaseKey.extractedArticle] = data
+                }
+                return d
+        }
 	
 	public var databaseID: String {
 		return articleID

--- a/Modules/ArticlesDatabase/Tests/ArticlesDatabaseTests/ExtractedArticleTests.swift
+++ b/Modules/ArticlesDatabase/Tests/ArticlesDatabaseTests/ExtractedArticleTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import ArticlesDatabase
+import Articles
+
+final class ExtractedArticleTests: XCTestCase {
+    func testEncodingDecoding() throws {
+        let status = ArticleStatus(articleID: "id", read: false, starred: false, dateArrived: Date())
+        let extracted = ExtractedArticle(title: "t", author: nil, datePublished: nil, dek: nil, leadImageURL: nil, content: "c", nextPageURL: nil, url: nil, domain: nil, excerpt: nil, wordCount: nil, direction: nil, totalPages: nil, renderedPages: nil)
+        let article = Article(accountID: "acc", articleID: "id", webFeedID: "feed", uniqueID: "uid", title: nil, contentHTML: nil, contentText: nil, url: nil, externalURL: nil, summary: nil, imageURL: nil, datePublished: nil, dateModified: nil, authors: nil, status: status, extractedArticle: extracted)
+        let dict = article.databaseDictionary()!
+        let data = dict[DatabaseKey.extractedArticle] as? Data
+        XCTAssertNotNil(data)
+        let decoded = try JSONDecoder().decode(ExtractedArticle.self, from: data!)
+        XCTAssertEqual(decoded, extracted)
+    }
+
+    func testSaveAndFetchExtractedArticle() throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let accountID = "acc"
+        let db = ArticlesDatabase(databaseFilePath: tempURL.path, accountID: accountID, retentionStyle: .feedBased)
+        let status = ArticleStatus(articleID: "id", read: false, starred: false, dateArrived: Date())
+        let article = Article(accountID: accountID, articleID: "id", webFeedID: "feed", uniqueID: "uid", title: nil, contentHTML: nil, contentText: nil, url: nil, externalURL: nil, summary: nil, imageURL: nil, datePublished: nil, dateModified: nil, authors: nil, status: status)
+        db.queue.runInDatabase { result in
+            let database = result.database!
+            database.executeUpdate("INSERT INTO articles (articleID, feedID, uniqueID) VALUES (?,?,?);", withArgumentsIn: [article.articleID, article.webFeedID, article.uniqueID])
+            database.executeUpdate("INSERT INTO statuses (articleID, read, starred, dateArrived) VALUES (?,?,?,?);", withArgumentsIn: [article.articleID, 0, 0, Date()])
+        }
+        let extracted = ExtractedArticle(title: "t", author: nil, datePublished: nil, dek: nil, leadImageURL: nil, content: "c", nextPageURL: nil, url: nil, domain: nil, excerpt: nil, wordCount: nil, direction: nil, totalPages: nil, renderedPages: nil)
+        db.saveExtractedArticle(extracted, for: article.articleID)
+        let fetched = try db.fetchArticles(articleIDs: Set([article.articleID])).first
+        XCTAssertEqual(fetched?.extractedArticle, extracted)
+    }
+}

--- a/iOS/Article/WebViewController.swift
+++ b/iOS/Article/WebViewController.swift
@@ -108,21 +108,28 @@ class WebViewController: UIViewController {
 	
 	// MARK: API
 
-	func setArticle(_ article: Article?, updateView: Bool = true) {
-		stopArticleExtractor()
-		
-		if article != self.article {
-			self.article = article
-			if updateView {
-				if article?.webFeed?.isArticleExtractorAlwaysOn ?? false {
-					startArticleExtractor()
-				}
-				windowScrollY = 0
-				loadWebView()
-			}
-		}
-		
-	}
+        func setArticle(_ article: Article?, updateView: Bool = true) {
+                stopArticleExtractor()
+
+                if article != self.article {
+                        self.article = article
+                        if updateView {
+                                if let extracted = article?.extractedArticle {
+                                        self.extractedArticle = extracted
+                                        isShowingExtractedArticle = true
+                                        articleExtractorButtonState = .on
+                                } else if article?.webFeed?.isArticleExtractorAlwaysOn ?? false {
+                                        startArticleExtractor()
+                                } else {
+                                        isShowingExtractedArticle = false
+                                        articleExtractorButtonState = .off
+                                }
+                                windowScrollY = 0
+                                loadWebView()
+                        }
+                }
+
+        }
 	
 	func setScrollPosition(isShowingExtractedArticle: Bool, articleWindowScrollY: Int) {
 		if isShowingExtractedArticle {
@@ -289,17 +296,20 @@ extension WebViewController: ArticleExtractorDelegate {
 		loadWebView()
 	}
 
-	func articleExtractionDidComplete(extractedArticle: ExtractedArticle) {
-		if articleExtractor?.state != .cancelled {
-			self.extractedArticle = extractedArticle
-			if let restoreWindowScrollY = restoreWindowScrollY {
-				windowScrollY = restoreWindowScrollY
-			}
-			isShowingExtractedArticle = true
-			loadWebView()
-			articleExtractorButtonState = .on
-		}
-	}
+        func articleExtractionDidComplete(extractedArticle: ExtractedArticle) {
+                if articleExtractor?.state != .cancelled {
+                        if let article = article {
+                                article.account?.saveExtractedArticle(extractedArticle, articleID: article.articleID)
+                        }
+                        self.extractedArticle = extractedArticle
+                        if let restoreWindowScrollY = restoreWindowScrollY {
+                                windowScrollY = restoreWindowScrollY
+                        }
+                        isShowingExtractedArticle = true
+                        loadWebView()
+                        articleExtractorButtonState = .on
+                }
+        }
 
 }
 


### PR DESCRIPTION
## Summary
- add database column `extractedArticle`
- persist extracted article data
- surface stored extracted article when changing selection
- update Article model and equality
- save extracted articles after extraction
- add unit tests for extracted article persistence

## Testing
- `swift test --package-path Modules/ArticlesDatabase` *(fails: use of '@import' when modules are disabled)*

------
https://chatgpt.com/codex/tasks/task_e_684157b489c88332b2b1fb1ddaf1b72c