### PR TITLE
Add article extraction progress indicator

### DIFF
--- a/Mac/MainWindow/Sidebar/SidebarStatusBarView.swift
+++ b/Mac/MainWindow/Sidebar/SidebarStatusBarView.swift
@@ -99,38 +99,43 @@ private extension SidebarStatusBarView {
 
 	func updateProgressIndicator() {
 
-		let progress = AccountManager.shared.combinedRefreshProgress
+                let refresh = AccountManager.shared.combinedRefreshProgress
+                let extraction = AccountManager.shared.combinedArticleExtractionProgress
 
-		if progress.isComplete {
-			stopProgressIfNeeded()
-			return
-		}
+                let totalTasks = refresh.numberOfTasks + extraction.numberOfTasks
+                let totalCompleted = refresh.numberCompleted + extraction.numberCompleted
 
-		startProgressIfNeeded()
+                if totalTasks == 0 {
+                        stopProgressIfNeeded()
+                        return
+                }
 
-		let maxValue = Double(progress.numberOfTasks)
-		if progressIndicator.maxValue != maxValue {
-			progressIndicator.maxValue = maxValue
-		}
+                startProgressIfNeeded()
 
-		let doubleValue = Double(progress.numberCompleted)
-		if progressIndicator.doubleValue != doubleValue {
-			progressIndicator.doubleValue = doubleValue
-		}
-	}
+                if progressIndicator.maxValue != Double(totalTasks) {
+                        progressIndicator.maxValue = Double(totalTasks)
+                }
+                if progressIndicator.doubleValue != Double(totalCompleted) {
+                        progressIndicator.doubleValue = Double(totalCompleted)
+                }
+        }
 
-	func updateProgressLabel() {
+        func updateProgressLabel() {
 
-		let progress = AccountManager.shared.combinedRefreshProgress
+                let refresh = AccountManager.shared.combinedRefreshProgress
+                let extraction = AccountManager.shared.combinedArticleExtractionProgress
 
-		if progress.isComplete {
-			progressLabel.stringValue = ""
-			return
-		}
+                let totalTasks = refresh.numberOfTasks + extraction.numberOfTasks
+                let totalCompleted = refresh.numberCompleted + extraction.numberCompleted
 
-		let formatString = NSLocalizedString("%@ of %@", comment: "Status bar progress")
-		let s = String(format: formatString, NSNumber(value: progress.numberCompleted), NSNumber(value: progress.numberOfTasks))
+                if totalTasks == 0 {
+                        progressLabel.stringValue = ""
+                        return
+                }
 
-		progressLabel.stringValue = s
-	}
+                let formatString = NSLocalizedString("%@ of %@", comment: "Status bar progress")
+                let s = String(format: formatString, NSNumber(value: totalCompleted), NSNumber(value: totalTasks))
+
+                progressLabel.stringValue = s
+        }
 }

--- a/Modules/Account/Sources/Account/Account.swift
+++ b/Modules/Account/Sources/Account/Account.swift
@@ -254,9 +254,13 @@ public final class Account: DisplayNameProvider, UnreadCountProvider, Container,
 		}
 	}
 
-	var refreshProgress: DownloadProgress {
-		return delegate.refreshProgress
-	}
+        var refreshProgress: DownloadProgress {
+                return delegate.refreshProgress
+        }
+
+       var articleExtractionProgress: DownloadProgress {
+               return delegate.articleExtractionProgress
+       }
 
 	init(dataFolder: String, type: AccountType, accountID: String, transport: Transport? = nil) {
 		switch type {

--- a/Modules/Account/Sources/Account/AccountDelegate.swift
+++ b/Modules/Account/Sources/Account/AccountDelegate.swift
@@ -21,7 +21,8 @@ protocol AccountDelegate {
 	var credentials: Credentials? { get set }
 	var accountMetadata: AccountMetadata? { get set }
 	
-	var refreshProgress: DownloadProgress { get }
+        var refreshProgress: DownloadProgress { get }
+       var articleExtractionProgress: DownloadProgress { get }
 
 	func receiveRemoteNotification(for account: Account, userInfo: [AnyHashable : Any], completion: @escaping () -> Void)
 

--- a/Modules/Account/Sources/Account/AccountManager.swift
+++ b/Modules/Account/Sources/Account/AccountManager.swift
@@ -89,7 +89,8 @@ public final class AccountManager: UnreadCountProvider {
 		return false
 	}
 
-	public let combinedRefreshProgress = CombinedRefreshProgress()
+        public let combinedRefreshProgress = CombinedRefreshProgress()
+       public let combinedArticleExtractionProgress = CombinedArticleExtractionProgress()
 
 	public init(accountsFolder: String) {
 		self.accountsFolder = accountsFolder

--- a/Modules/Account/Sources/Account/CombinedArticleExtractionProgress.swift
+++ b/Modules/Account/Sources/Account/CombinedArticleExtractionProgress.swift
@@ -1,0 +1,65 @@
+//
+//  CombinedArticleExtractionProgress.swift
+//  NetNewsWire
+//
+//  Created by Codex on 2023-11-23.
+//
+
+import Foundation
+import RSWeb
+
+extension Notification.Name {
+    public static let combinedArticleExtractionProgressDidChange = Notification.Name("combinedArticleExtractionProgressDidChange")
+}
+
+/// Combine article extraction progress from multiple accounts for display purposes.
+public final class CombinedArticleExtractionProgress {
+
+    public private(set) var numberOfTasks = 0
+    public private(set) var numberRemaining = 0
+    public private(set) var numberCompleted = 0
+
+    public var isComplete: Bool {
+        return numberRemaining < 1
+    }
+
+    init() {
+        NotificationCenter.default.addObserver(self, selector: #selector(progressDidChange(_:)), name: .DownloadProgressDidChange, object: nil)
+    }
+
+    @objc func progressDidChange(_ notification: Notification) {
+        var updatedNumberOfTasks = 0
+        var updatedNumberRemaining = 0
+        var updatedNumberCompleted = 0
+        var didMakeChange = false
+
+        let progresses = AccountManager.shared.activeAccounts.map { $0.articleExtractionProgress }
+        for progress in progresses {
+            updatedNumberOfTasks += progress.numberOfTasks
+            updatedNumberRemaining += progress.numberRemaining
+            updatedNumberCompleted += progress.numberCompleted
+        }
+
+        if updatedNumberOfTasks != numberOfTasks {
+            numberOfTasks = updatedNumberOfTasks
+            didMakeChange = true
+        }
+
+        updatedNumberRemaining = min(updatedNumberRemaining, numberOfTasks)
+        if updatedNumberRemaining != numberRemaining {
+            numberRemaining = updatedNumberRemaining
+            didMakeChange = true
+        }
+
+        updatedNumberCompleted = min(updatedNumberCompleted, numberOfTasks)
+        if updatedNumberCompleted != numberCompleted {
+            numberCompleted = updatedNumberCompleted
+            didMakeChange = true
+        }
+
+        if didMakeChange {
+            NotificationCenter.default.post(name: .combinedArticleExtractionProgressDidChange, object: self)
+        }
+    }
+}
+

--- a/Modules/Account/Sources/Account/Feedbin/FeedbinAccountDelegate.swift
+++ b/Modules/Account/Sources/Account/Feedbin/FeedbinAccountDelegate.swift
@@ -43,7 +43,8 @@ final class FeedbinAccountDelegate: AccountDelegate {
 		}
 	}
 	
-	var refreshProgress = DownloadProgress(numberOfTasks: 0)
+        var refreshProgress = DownloadProgress(numberOfTasks: 0)
+       var articleExtractionProgress = DownloadProgress(numberOfTasks: 0)
 
 	init(dataFolder: String, transport: Transport?) {
 		

--- a/Modules/Account/Sources/Account/Feedly/FeedlyAccountDelegate.swift
+++ b/Modules/Account/Sources/Account/Feedly/FeedlyAccountDelegate.swift
@@ -53,7 +53,8 @@ final class FeedlyAccountDelegate: AccountDelegate {
 	
 	var accountMetadata: AccountMetadata?
 	
-	var refreshProgress = DownloadProgress(numberOfTasks: 0)
+        var refreshProgress = DownloadProgress(numberOfTasks: 0)
+       var articleExtractionProgress = DownloadProgress(numberOfTasks: 0)
 	
 	/// Set on `accountDidInitialize` for the purposes of refreshing OAuth tokens when they expire.
 	/// See the implementation for `FeedlyAPICallerDelegate`.

--- a/Modules/Account/Sources/Account/NewsBlur/NewsBlurAccountDelegate.swift
+++ b/Modules/Account/Sources/Account/NewsBlur/NewsBlurAccountDelegate.swift
@@ -27,8 +27,9 @@ final class NewsBlurAccountDelegate: AccountDelegate {
 		}
 	}
 
-	var accountMetadata: AccountMetadata? = nil
-	var refreshProgress = DownloadProgress(numberOfTasks: 0)
+        var accountMetadata: AccountMetadata? = nil
+        var refreshProgress = DownloadProgress(numberOfTasks: 0)
+       var articleExtractionProgress = DownloadProgress(numberOfTasks: 0)
 
 	let caller: NewsBlurAPICaller
 	let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "NewsBlur")

--- a/Modules/Account/Sources/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
+++ b/Modules/Account/Sources/Account/ReaderAPI/ReaderAPIAccountDelegate.swift
@@ -71,7 +71,8 @@ final class ReaderAPIAccountDelegate: AccountDelegate {
 		}
 	}
 
-	var refreshProgress = DownloadProgress(numberOfTasks: 0)
+        var refreshProgress = DownloadProgress(numberOfTasks: 0)
+       var articleExtractionProgress = DownloadProgress(numberOfTasks: 0)
 	
 	init(dataFolder: String, transport: Transport?, variant: ReaderAPIVariant) {
 		let databaseFilePath = (dataFolder as NSString).appendingPathComponent("Sync.sqlite3")

--- a/Modules/ArticleExtractor/Sources/ArticleExtractor/ArticleExtractionOperation.swift
+++ b/Modules/ArticleExtractor/Sources/ArticleExtractor/ArticleExtractionOperation.swift
@@ -1,10 +1,12 @@
 import Foundation
 import Articles
+import RSWeb
 
 public final class ArticleExtractionOperation: Operation, ArticleExtractorDelegate {
     private var extractor: ArticleExtractor?
     private let article: Article
-	private let saveHandler: (ExtractedArticle, String) -> Void
+    private let progress: DownloadProgress?
+    private let saveHandler: (ExtractedArticle, String) -> Void
 
     private var _isExecuting = false
     private var _isFinished = false
@@ -27,11 +29,12 @@ public final class ArticleExtractionOperation: Operation, ArticleExtractorDelega
         }
     }
 
-	public init?(article: Article, saveHandler: @escaping (ExtractedArticle, String) -> Void) {
-		guard let link = article.linkForExtraction, let extractor = ArticleExtractor(link,skipParsing: true) else { return nil }
+    public init?(article: Article, progress: DownloadProgress? = nil, saveHandler: @escaping (ExtractedArticle, String) -> Void) {
+        guard let link = article.linkForExtraction, let extractor = ArticleExtractor(link,skipParsing: true) else { return nil }
         self.article = article
         self.extractor = extractor
-		self.saveHandler = saveHandler
+        self.progress = progress
+        self.saveHandler = saveHandler
         super.init()
     }
 
@@ -57,7 +60,10 @@ public final class ArticleExtractionOperation: Operation, ArticleExtractorDelega
 
     private func finish() {
         if isExecuting { isExecuting = false }
-        if !isFinished { isFinished = true }
+        if !isFinished {
+            isFinished = true
+            progress?.completeTask()
+        }
     }
 
     // MARK: ArticleExtractorDelegate


### PR DESCRIPTION
## Summary
- track article extraction progress across accounts
- expose progress via `AccountManager` and `SidebarStatusBarView`
- update account delegates and article extraction operation

## Testing
- `./buildscripts/quiet_build_and_test.sh` *(fails: xcbeautify: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499f8285308332af5c1c1ded47e2ff