### PR TITLE
Add option for user-defined Smart Feeds

### DIFF
--- a/Mac/AppDefaults.swift
+++ b/Mac/AppDefaults.swift
@@ -38,10 +38,11 @@ final class AppDefaults {
 		static let addWebFeedFolderName = "addWebFeedFolderName"
 		static let addFolderAccountID = "addFolderAccountID"
 		static let importOPMLAccountID = "importOPMLAccountID"
-		static let exportOPMLAccountID = "exportOPMLAccountID"
-		static let defaultBrowserID = "defaultBrowserID"
-		static let currentThemeName = "currentThemeName"
-		static let articleContentJavascriptEnabled = "articleContentJavascriptEnabled"
+                static let exportOPMLAccountID = "exportOPMLAccountID"
+                static let defaultBrowserID = "defaultBrowserID"
+                static let currentThemeName = "currentThemeName"
+                static let articleContentJavascriptEnabled = "articleContentJavascriptEnabled"
+                static let smartFeedKeywords = "smartFeedKeywords"
 
 		// Hidden prefs
 		static let showDebugMenu = "ShowDebugMenu"
@@ -185,14 +186,23 @@ final class AppDefaults {
 		}
 	}
 	
-	var exportOPMLAccountID: String? {
-		get {
-			return AppDefaults.string(for: Key.exportOPMLAccountID)
-		}
-		set {
-			AppDefaults.setString(for: Key.exportOPMLAccountID, newValue)
-		}
-	}
+        var exportOPMLAccountID: String? {
+                get {
+                        return AppDefaults.string(for: Key.exportOPMLAccountID)
+                }
+                set {
+                        AppDefaults.setString(for: Key.exportOPMLAccountID, newValue)
+                }
+        }
+
+        var smartFeedKeywords: [String] {
+                get {
+                        return UserDefaults.standard.stringArray(forKey: Key.smartFeedKeywords) ?? []
+                }
+                set {
+                        UserDefaults.standard.set(newValue, forKey: Key.smartFeedKeywords)
+                }
+        }
 
 	var defaultBrowserID: String? {
 		get {

--- a/Mac/AppDelegate.swift
+++ b/Mac/AppDelegate.swift
@@ -455,13 +455,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 			return !isDisplayingSheet && !AccountManager.shared.anyAccountHasNetNewsWireNewsSubscription() && !AccountManager.shared.activeAccounts.isEmpty
 		}
 		
-		if item.action == #selector(sortByNewestArticleOnTop(_:)) || item.action == #selector(sortByOldestArticleOnTop(_:)) {
-			return mainWindowController?.isOpen ?? false
-		}
-		
-		if item.action == #selector(showAddWebFeedWindow(_:)) || item.action == #selector(showAddFolderWindow(_:)) {
-			return !isDisplayingSheet && !AccountManager.shared.activeAccounts.isEmpty
-		}
+                if item.action == #selector(sortByNewestArticleOnTop(_:)) || item.action == #selector(sortByOldestArticleOnTop(_:)) {
+                        return mainWindowController?.isOpen ?? false
+                }
+
+                if item.action == #selector(showAddWebFeedWindow(_:)) || item.action == #selector(showAddFolderWindow(_:)) || item.action == #selector(showAddSmartFeedWindow(_:)) {
+                        return !isDisplayingSheet && !AccountManager.shared.activeAccounts.isEmpty
+                }
 		
 		#if !MAC_APP_STORE
 		if item.action == #selector(toggleWebInspectorEnabled(_:)) {
@@ -538,10 +538,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserInterfaceValidations, 
 		addWebFeed(nil)
 	}
 
-	@IBAction func showAddFolderWindow(_ sender: Any?) {
-		createAndShowMainWindowIfNecessary()
-		showAddFolderSheetOnWindow(mainWindowController!.window!)
-	}
+        @IBAction func showAddFolderWindow(_ sender: Any?) {
+                createAndShowMainWindowIfNecessary()
+                showAddFolderSheetOnWindow(mainWindowController!.window!)
+        }
+
+        @IBAction func showAddSmartFeedWindow(_ sender: Any?) {
+                createAndShowMainWindowIfNecessary()
+                let alert = NSAlert()
+                alert.messageText = NSLocalizedString("New Smart Feed", comment: "New Smart Feed")
+                alert.informativeText = NSLocalizedString("Enter a keyword to create a smart feed that searches article titles and content.", comment: "Add Smart Feed Informative Text")
+                let textField = NSTextField(string: "")
+                textField.frame = NSRect(x: 0, y: 0, width: 240, height: 24)
+                alert.accessoryView = textField
+                alert.addButton(withTitle: NSLocalizedString("OK", comment: "OK"))
+                alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "Cancel"))
+                if alert.runModal() == .alertFirstButtonReturn {
+                        let keyword = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !keyword.isEmpty {
+                                SmartFeedsController.shared.addSearchFeed(keyword: keyword)
+                        }
+                }
+        }
 
 	@IBAction func showKeyboardShortcutsWindow(_ sender: Any?) {
 		if keyboardShortcutsWindowController == nil {

--- a/Mac/MainWindow/MainWindowController.swift
+++ b/Mac/MainWindow/MainWindowController.swift
@@ -1425,13 +1425,18 @@ private extension MainWindowController {
 		newWebFeedItem.action = Selector(("showAddWebFeedWindow:"))
 		menu.addItem(newWebFeedItem)
 		
-		let newFolderFeedItem = NSMenuItem()
-		newFolderFeedItem.title = NSLocalizedString("New Folder…", comment: "New Folder")
-		newFolderFeedItem.action = Selector(("showAddFolderWindow:"))
-		menu.addItem(newFolderFeedItem)
-		
-		return menu
-	}
+                let newFolderFeedItem = NSMenuItem()
+                newFolderFeedItem.title = NSLocalizedString("New Folder…", comment: "New Folder")
+                newFolderFeedItem.action = Selector(("showAddFolderWindow:"))
+                menu.addItem(newFolderFeedItem)
+
+                let newSmartFeedItem = NSMenuItem()
+                newSmartFeedItem.title = NSLocalizedString("New Smart Feed…", comment: "New Smart Feed")
+                newSmartFeedItem.action = Selector(("showAddSmartFeedWindow:"))
+                menu.addItem(newSmartFeedItem)
+
+                return menu
+        }
 
 	func updateArticleThemeMenu() {
 		let articleThemeMenu = NSMenu()

--- a/Mac/MainWindow/Sidebar/SidebarViewController+ContextualMenus.swift
+++ b/Mac/MainWindow/Sidebar/SidebarViewController+ContextualMenus.swift
@@ -362,8 +362,9 @@ private extension SidebarViewController {
 
 		let menu = NSMenu(title: "")
 
-		menu.addItem(withTitle: NSLocalizedString("New Feed", comment: "Command"), action: #selector(AppDelegate.showAddWebFeedWindow(_:)), keyEquivalent: "")
-		menu.addItem(withTitle: NSLocalizedString("New Folder", comment: "Command"), action: #selector(AppDelegate.showAddFolderWindow(_:)), keyEquivalent: "")
+        menu.addItem(withTitle: NSLocalizedString("New Feed", comment: "Command"), action: #selector(AppDelegate.showAddWebFeedWindow(_:)), keyEquivalent: "")
+        menu.addItem(withTitle: NSLocalizedString("New Folder", comment: "Command"), action: #selector(AppDelegate.showAddFolderWindow(_:)), keyEquivalent: "")
+        menu.addItem(withTitle: NSLocalizedString("New Smart Feed", comment: "Command"), action: #selector(AppDelegate.showAddSmartFeedWindow(_:)), keyEquivalent: "")
 
 		return menu
 	}

--- a/Shared/SmartFeeds/SearchFeedDelegate.swift
+++ b/Shared/SmartFeeds/SearchFeedDelegate.swift
@@ -14,9 +14,9 @@ import ArticlesDatabase
 
 struct SearchFeedDelegate: SmartFeedDelegate {
 
-	var feedID: FeedIdentifier? {
-		return FeedIdentifier.smartFeed(String(describing: SearchFeedDelegate.self))
-	}
+        var feedID: FeedIdentifier? {
+                return FeedIdentifier.smartFeed("search:\(searchString)")
+        }
 
 	var nameForDisplay: String {
 		return nameForDisplayPrefix + searchString

--- a/Shared/SmartFeeds/SearchTimelineFeedDelegate.swift
+++ b/Shared/SmartFeeds/SearchTimelineFeedDelegate.swift
@@ -14,9 +14,9 @@ import ArticlesDatabase
 
 struct SearchTimelineFeedDelegate: SmartFeedDelegate {
 
-	var feedID: FeedIdentifier? {
-		return FeedIdentifier.smartFeed(String(describing: SearchTimelineFeedDelegate.self))
-	}
+        var feedID: FeedIdentifier? {
+                return FeedIdentifier.smartFeed("search:\(searchString)")
+        }
 
 	var nameForDisplay: String {
 		return nameForDisplayPrefix + searchString

--- a/Shared/SmartFeeds/SmartFeedsController.swift
+++ b/Shared/SmartFeeds/SmartFeedsController.swift
@@ -16,34 +16,47 @@ final class SmartFeedsController: DisplayNameProvider, ContainerIdentifiable {
 		return ContainerIdentifier.smartFeedController
 	}
 
-	public static let shared = SmartFeedsController()
-	let nameForDisplay = NSLocalizedString("Smart Feeds", comment: "Smart Feeds group title")
+        public static let shared = SmartFeedsController()
+        let nameForDisplay = NSLocalizedString("Smart Feeds", comment: "Smart Feeds group title")
 
-	var smartFeeds = [Feed]()
-	let todayFeed = SmartFeed(delegate: TodayFeedDelegate())
-	let unreadFeed = UnreadFeed()
-	let starredFeed = SmartFeed(delegate: StarredFeedDelegate())
+        private var userSearchKeywords = [String]()
+        private var userSearchFeeds = [SmartFeed]()
 
-	private init() {
-		self.smartFeeds = [todayFeed, unreadFeed, starredFeed]
-	}
-	
-	func find(by identifier: FeedIdentifier) -> PseudoFeed? {
-		switch identifier {
-		case .smartFeed(let stringIdentifer):
-			switch stringIdentifer {
-			case String(describing: TodayFeedDelegate.self):
-				return todayFeed
-			case String(describing: UnreadFeed.self):
-				return unreadFeed
-			case String(describing: StarredFeedDelegate.self):
-				return starredFeed
-			default:
-				return nil
-			}
-		default:
-			return nil
-		}
-	}
-	
+        private(set) var smartFeeds = [Feed]()
+        let todayFeed = SmartFeed(delegate: TodayFeedDelegate())
+        let unreadFeed = UnreadFeed()
+        let starredFeed = SmartFeed(delegate: StarredFeedDelegate())
+
+        private init() {
+                userSearchKeywords = AppDefaults.shared.smartFeedKeywords
+                userSearchFeeds = userSearchKeywords.map { SmartFeed(delegate: SearchFeedDelegate(searchString: $0)) }
+                rebuildSmartFeeds()
+        }
+
+        func addSearchFeed(keyword: String) {
+                guard !userSearchKeywords.contains(keyword) else { return }
+                userSearchKeywords.append(keyword)
+                userSearchFeeds.append(SmartFeed(delegate: SearchFeedDelegate(searchString: keyword)))
+                saveSearchKeywords()
+                rebuildSmartFeeds()
+                NotificationCenter.default.post(name: .ChildrenDidChange, object: self)
+        }
+
+        private func rebuildSmartFeeds() {
+                smartFeeds = [todayFeed, unreadFeed, starredFeed] + userSearchFeeds
+        }
+
+        private func saveSearchKeywords() {
+                AppDefaults.shared.smartFeedKeywords = userSearchKeywords
+        }
+
+        func find(by identifier: FeedIdentifier) -> PseudoFeed? {
+                for feed in smartFeeds {
+                        if let id = feed.feedID, id == identifier {
+                                return feed as? PseudoFeed
+                        }
+                }
+                return nil
+        }
+
 }

--- a/iOS/AppDefaults.swift
+++ b/iOS/AppDefaults.swift
@@ -55,9 +55,10 @@ final class AppDefaults {
 		static let addWebFeedAccountID = "addWebFeedAccountID"
 		static let addWebFeedFolderName = "addWebFeedFolderName"
 		static let addFolderAccountID = "addFolderAccountID"
-		static let useSystemBrowser = "useSystemBrowser"
-		static let currentThemeName = "currentThemeName"
-	}
+                static let useSystemBrowser = "useSystemBrowser"
+                static let currentThemeName = "currentThemeName"
+                static let smartFeedKeywords = "smartFeedKeywords"
+        }
 
 	let isDeveloperBuild: Bool = {
 		if let dev = Bundle.main.object(forInfoDictionaryKey: "DeveloperEntitlements") as? String, dev == "-dev" {
@@ -104,14 +105,23 @@ final class AppDefaults {
 		}
 	}
 	
-	var addFolderAccountID: String? {
-		get {
-			return AppDefaults.string(for: Key.addFolderAccountID)
-		}
-		set {
-			AppDefaults.setString(for: Key.addFolderAccountID, newValue)
-		}
-	}
+        var addFolderAccountID: String? {
+                get {
+                        return AppDefaults.string(for: Key.addFolderAccountID)
+                }
+                set {
+                        AppDefaults.setString(for: Key.addFolderAccountID, newValue)
+                }
+        }
+
+        var smartFeedKeywords: [String] {
+                get {
+                        return AppDefaults.store.stringArray(forKey: Key.smartFeedKeywords) ?? []
+                }
+                set {
+                        AppDefaults.store.set(newValue, forKey: Key.smartFeedKeywords)
+                }
+        }
 	
 	var useSystemBrowser: Bool {
 		get {


### PR DESCRIPTION
## Summary
- allow creation of custom Smart Feeds based on a keyword search
- persist custom Smart Feed keywords and surface them in Smart Feeds list
- add menu entries for creating Smart Feeds

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_68aae51c3f5083329a177990d8e82d81